### PR TITLE
DeviceManager: editable Username field + sofia_hash signature fix

### DIFF
--- a/DeviceManager.py
+++ b/DeviceManager.py
@@ -172,7 +172,7 @@ def local_ip():
     )
 
 
-def sofia_hash(self, password):
+def sofia_hash(password):
     md5 = hashlib.md5(bytes(password, "utf-8")).digest()
     chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
     return "".join([chars[sum(x) % 62] for x in zip(md5[::2], md5[1::2])])
@@ -202,7 +202,6 @@ def GetAllAddr():
             for x in str(check_output(iptool), "ascii").split("\n")
             if "inet " in x and "127.0." not in x
         ]
-
 
 def SearchXM(devices):
     server = socket(AF_INET, SOCK_DGRAM)
@@ -438,6 +437,7 @@ def SearchBeward(devices):
 
 def ConfigXM(data):
     config = {}
+
     #TODO: may be just copy whwole devices[data[1]] to config?
     for k in [u"HostName",u"HttpPort",u"MAC",u"MaxBps",u"MonMode",u"SSLPort",u"TCPMaxConn",u"TCPPort",u"TransferPlan",u"UDPPort","UseHSDownLoad"]:
         if k in devices[data[1]]:
@@ -447,8 +447,9 @@ def ConfigXM(data):
     config[u"GateWay"] = SetIP(data[4])
     config[u"HostIP"] = SetIP(data[2])
     config[u"Submask"] = SetIP(data[3])
-    config[u"Username"] = "admin"
+    config[u"Username"] = data[6] #"admin"
     config[u"Password"] = sofia_hash(data[5])
+
     devices[data[1]][u"GateWay"] = config[u"GateWay"]
     devices[data[1]][u"HostIP"] = config[u"HostIP"]
     devices[data[1]][u"Submask"] = config[u"Submask"]
@@ -934,12 +935,16 @@ class GUITk:
         self.l5.grid(row=6, column=0, pady=3, padx=5, sticky=W + N)
         self.tcp = Entry(self.fr_config, width=5, font="6")
         self.tcp.grid(row=6, column=1, pady=3, padx=5, sticky=W + N)
-        self.l6 = Label(self.fr_config, text=_("Password"))
+        self.l6 = Label(self.fr_config, text=_("Username"))
         self.l6.grid(row=7, column=0, pady=3, padx=5, sticky=W + N)
+        self.username = Entry(self.fr_config, width=15, font="6")
+        self.username.grid(row=7, column=1, pady=3, padx=5, sticky=W + N)
+        self.l6 = Label(self.fr_config, text=_("Password"))
+        self.l6.grid(row=8, column=0, pady=3, padx=5, sticky=W + N)        
         self.passw = Entry(self.fr_config, width=15, font="6")
-        self.passw.grid(row=7, column=1, pady=3, padx=5, sticky=W + N)
+        self.passw.grid(row=8, column=1, pady=3, padx=5, sticky=W + N)
         self.aply = Button(self.fr_config, text=_("Apply"), command=self.setconfig)
-        self.aply.grid(row=8, column=1, pady=3, padx=5, sticky="ew")
+        self.aply.grid(row=9, column=1, pady=3, padx=5, sticky="ew")
 
         self.l7 = Label(self.fr_tools, text=_("Vendor"))
         self.l7.grid(row=0, column=0, pady=3, padx=5, sticky="wns")
@@ -1020,6 +1025,8 @@ class GUITk:
         self.http.insert(END, devices[dev]["HttpPort"])
         self.tcp.delete(0, END)
         self.tcp.insert(END, devices[dev]["TCPPort"])
+        self.username.delete(0, END)
+        self.username.insert(END, "admin")
 
     def setconfig(self):
         dev = self.table.item(self.table.selection()[0], option="values")[0]
@@ -1034,6 +1041,7 @@ class GUITk:
                 self.mask.get(),
                 self.gate.get(),
                 self.passw.get(),
+                self.username.get(),
             ]
         )
         if result["Ret"] == 100:

--- a/DeviceManager.py
+++ b/DeviceManager.py
@@ -203,6 +203,7 @@ def GetAllAddr():
             if "inet " in x and "127.0." not in x
         ]
 
+
 def SearchXM(devices):
     server = socket(AF_INET, SOCK_DGRAM)
     server.bind(("", 34569))
@@ -437,7 +438,6 @@ def SearchBeward(devices):
 
 def ConfigXM(data):
     config = {}
-
     #TODO: may be just copy whwole devices[data[1]] to config?
     for k in [u"HostName",u"HttpPort",u"MAC",u"MaxBps",u"MonMode",u"SSLPort",u"TCPMaxConn",u"TCPPort",u"TransferPlan",u"UDPPort","UseHSDownLoad"]:
         if k in devices[data[1]]:
@@ -447,9 +447,8 @@ def ConfigXM(data):
     config[u"GateWay"] = SetIP(data[4])
     config[u"HostIP"] = SetIP(data[2])
     config[u"Submask"] = SetIP(data[3])
-    config[u"Username"] = data[6] #"admin"
+    config[u"Username"] = data[6]
     config[u"Password"] = sofia_hash(data[5])
-
     devices[data[1]][u"GateWay"] = config[u"GateWay"]
     devices[data[1]][u"HostIP"] = config[u"HostIP"]
     devices[data[1]][u"Submask"] = config[u"Submask"]
@@ -935,12 +934,12 @@ class GUITk:
         self.l5.grid(row=6, column=0, pady=3, padx=5, sticky=W + N)
         self.tcp = Entry(self.fr_config, width=5, font="6")
         self.tcp.grid(row=6, column=1, pady=3, padx=5, sticky=W + N)
-        self.l6 = Label(self.fr_config, text=_("Username"))
-        self.l6.grid(row=7, column=0, pady=3, padx=5, sticky=W + N)
+        self.l8 = Label(self.fr_config, text=_("Username"))
+        self.l8.grid(row=7, column=0, pady=3, padx=5, sticky=W + N)
         self.username = Entry(self.fr_config, width=15, font="6")
         self.username.grid(row=7, column=1, pady=3, padx=5, sticky=W + N)
         self.l6 = Label(self.fr_config, text=_("Password"))
-        self.l6.grid(row=8, column=0, pady=3, padx=5, sticky=W + N)        
+        self.l6.grid(row=8, column=0, pady=3, padx=5, sticky=W + N)
         self.passw = Entry(self.fr_config, width=15, font="6")
         self.passw.grid(row=8, column=1, pady=3, padx=5, sticky=W + N)
         self.aply = Button(self.fr_config, text=_("Apply"), command=self.setconfig)
@@ -1026,7 +1025,7 @@ class GUITk:
         self.tcp.delete(0, END)
         self.tcp.insert(END, devices[dev]["TCPPort"])
         self.username.delete(0, END)
-        self.username.insert(END, "admin")
+        self.username.insert(END, devices[dev].get("Username", "admin"))
 
     def setconfig(self):
         dev = self.table.item(self.table.selection()[0], option="values")[0]


### PR DESCRIPTION
Supersedes #2 (original work by @rloadd, preserved as the first commit on this branch).

## Summary
- Fix `sofia_hash()` at module scope in `DeviceManager.py` — the bogus `self` parameter made the existing `sofia_hash(data[5])` call site silently bind the password to `self`, leaving `password` unfilled.
- Add a Username `Entry` widget to the config panel so the GUI can configure accounts other than `admin`. `ConfigXM` now reads `data[6]` for `Username` instead of hardcoding `"admin"`.
- Cleanup commit on top of @rloadd's change:
  - revert whitespace-only edits (blank line between `GetAllAddr` and `SearchXM`, blank lines in `ConfigXM`, trailing whitespace on the Password label grid call)
  - rename the duplicated `self.l6` used for the new Username label to `self.l8` so the Password label's `self.l6` isn't shadowed
  - prefill the Username entry from `devices[dev]` when the discovered value is available, falling back to `"admin"` only when missing
  - drop the inline `#"admin"` trailing comment

In-class `DVRIPCam.sofia_hash` in `dvrip.py` and `asyncio_dvrip.py` are real methods and intentionally untouched.

## Test plan
- [ ] `python3 DeviceManager.py` launches the Tk GUI
- [ ] Search finds an XM device, selecting it prefills the Username field (admin or device-reported value)
- [ ] Editing Username + Password and clicking Apply pushes the new credentials (Ret == 100)
- [ ] Headless fallback (no Tk) still works for `search` / `config` CLI subcommands