### PR TITLE
dvrip: add Detect (motion detection) config wrappers

### DIFF
--- a/AlarmServer.py
+++ b/AlarmServer.py
@@ -40,7 +40,7 @@ while True:
         sleep(0.1)  # Just for recive whole packet
         data = conn.recv(len_data)
         conn.close()
-        reply = json.loads(data, encoding="utf8")
+        reply = json.loads(data.decode("utf-8", errors="replace").rstrip("\x00\n"))
         print(datetime.now().strftime("[%Y-%m-%d %H:%M:%S]>>>"))
         print(head, version, session, sequence_number, msgid, len_data)
         print(json.dumps(reply, indent=4, sort_keys=True))

--- a/README.md
+++ b/README.md
@@ -460,6 +460,43 @@ cloudEnabled = False
 cam.set_info("NetWork.Nat", { "NatEnable" : cloudEnabled })
 ```
 
+## Motion detection
+
+Xiongmai cameras typically do **not** expose ONVIF `AnalyticsService`, so
+motion detection cannot be configured through ONVIF. On some firmwares it
+is also off by default. Configure it directly over the native protocol via
+the `Detect` config path:
+
+```python
+# Inspect current config (per-channel arrays)
+print(cam.get_detect_info())
+# {'HumanDetection': [{'Enable': False, ...}],
+#  'MotionDetect':  [{'Enable': True,
+#                     'EventHandler': {'RecordEnable': True,
+#                                      'AlarmOutEnable': False, ...},
+#                     'Level': 5}]}
+
+# Enable motion detection at sensitivity 5 with event-triggered recording.
+# Sparse payloads are merged — fields you omit keep their current values.
+cam.set_detect_info({
+    "MotionDetect":   [{"Enable": True,
+                        "EventHandler": {"RecordEnable": True},
+                        "Level": 5}],
+    "HumanDetection": [{"Enable": False}],
+})
+```
+
+The equivalent low-level call is `cam.set_info("Detect", ...)` — both
+shapes work; the wrapper just documents the path.
+
+Receiving the events is a separate problem. Some XM firmwares push
+`AlarmInfo` packets over the existing TCP session, so registering
+`setAlarm()` + `alarmStart()` is enough; on others the camera only emits
+to a separately-configured alarm server (see `AlarmServer.py` and the
+`EventHandler.AlarmInfo` / `MsgtoNetEnable` fields). If `setAlarm()`
+silently produces no callbacks even while recordings show motion is
+detected, the camera is likely in the latter group.
+
 ## Add user and change password
 
 ```python

--- a/asyncio_dvrip.py
+++ b/asyncio_dvrip.py
@@ -580,6 +580,14 @@ class DVRIPCam(object):
             code = 1042
         return await self.get_command("Simplify.Encode", code)
 
+    async def get_detect_info(self):
+        """Read 'Detect' config: per-channel MotionDetect / HumanDetection / etc."""
+        return await self.get_info("Detect")
+
+    async def set_detect_info(self, data):
+        """Update 'Detect' config. Sparse payloads are merged with current state."""
+        return await self.set_info("Detect", data)
+
     async def recv_json(self, buf=bytearray()):
         p = compile(b".*({.*})")
 

--- a/connect.py
+++ b/connect.py
@@ -27,6 +27,13 @@ info["OSDInfo"][0]["OSDInfoWidget"]["PreviewBlend"] = True
 # info["OSDInfo"][0]["OSDInfoWidget"]["RelativePos"] = [6144,6144,8192,8192]
 cam.set_info("fVideo.OSDInfo", info)
 # enc_info = cam.get_info("Simplify.Encode")
+# Motion detection: turn it on and route events into recording.
+# cam.set_detect_info({
+#     "MotionDetect":   [{"Enable": True,
+#                         "EventHandler": {"RecordEnable": True},
+#                         "Level": 5}],
+#     "HumanDetection": [{"Enable": False}],
+# })
 # Alarm example
 def alarm(content, ids):
     print(content)

--- a/dvrip.py
+++ b/dvrip.py
@@ -703,6 +703,14 @@ class DVRIPCam(object):
             code = 1042
         return self.get_command("Simplify.Encode", code)
 
+    def get_detect_info(self):
+        """Read 'Detect' config: per-channel MotionDetect / HumanDetection / etc."""
+        return self.get_info("Detect")
+
+    def set_detect_info(self, data):
+        """Update 'Detect' config. Sparse payloads are merged with current state."""
+        return self.set_info("Detect", data)
+
     def recv_json(self, buf=bytearray()):
         p = compile(b".*({.*})")
 


### PR DESCRIPTION
## Summary

- Add `get_detect_info()` / `set_detect_info(data)` thin wrappers in both sync (`dvrip.py`) and async (`asyncio_dvrip.py`) clients for the top-level `Detect` config path. The path was already reachable through `get_info` / `set_info`; this just documents it as part of the stable API alongside `get_encode_info`, `get_camera_info`, etc.
- Document the per-channel-array schema and the sparse-merge SET behaviour in README, with the canonical OpenIPC "turn motion detection on" snippet. XM cameras don't expose this through ONVIF (no `AnalyticsService`), so the native path is the only one — having it documented saves the next user a reverse-engineering session.
- Note in the same section that alarm reception is firmware-dependent: some builds push `AlarmInfo` over the existing TCP session (so `setAlarm()` / `alarmStart()` is enough), some only push to a separately-configured `AlarmServer`, and some don't push at all.
- Commented-out example in `connect.py`.
- Drive-by: `AlarmServer.py` was crashing on the first packet under Python 3.9+ because `json.loads(data, encoding="utf8")` uses an `encoding` kwarg that was removed in 3.9. Fixed by decoding once and trimming the `\x00\n` framing tail before parsing.

## Test plan

- [x] `from dvrip import DVRIPCam` and `from asyncio_dvrip import DVRIPCam` both import cleanly; `get_detect_info` / `set_detect_info` exist on both classes
- [x] Verified live on an XM IPC unit (single-channel street camera, hostname `IVG85HG50PYA-S-2`): `cam.get_detect_info()` returns `{HumanDetection: [...], MotionDetect: [...]}` per-channel arrays
- [x] `cam.set_detect_info(snippet_from_readme)` returns `Ret: 100`; readback confirms `MotionDetect[0].Enable == True` and `Level == 5`
- [x] Sparse merge: writing `{"MotionDetect":[{"Level":4}]}` flips only `Level`, preserves `EventHandler.RecordEnable`, `MessageEnable`, etc.
- [x] `AlarmServer.py` accepts a hand-crafted `AlarmInfo` (msgid 1504) packet over loopback on Python 3.13 and prints the parsed JSON instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)