### PR TITLE
upgrade(): log the response just read, not a stale variable

### DIFF
--- a/dvrip.py
+++ b/dvrip.py
@@ -771,7 +771,7 @@ class DVRIPCam(object):
         self.logger.debug("Starting upgrade...")
         while True:
             data, rcvd = self.recv_json(rcvd)
-            self.logger.debug(reply)
+            self.logger.debug(data)
             if data is None:
                 vprint("\nDone")
                 return


### PR DESCRIPTION
`upgrade()`'s completion loop reads each response into `data` but logs `reply`:

```python
while True:
    data, rcvd = self.recv_json(rcvd)
    self.logger.debug(reply)      # <- stale
    if data is None:
        ...
```

`reply` was last assigned in the upload loop above and is never reassigned here, so every iteration logs the same stale value rather than the upgrade response the line is meant to record.

Debug-level only, so it isn't visible by default — but it makes the upgrade log actively misleading once enabled, since the `Ret` values recorded can repeat or show a value the camera never sent at that point. I hit this while tracing why firmware upgrades on a GK7205V200 camera reported inconsistent results, and the log sent me the wrong way for a while.

One-line change, no behaviour difference outside logging.

Thanks for maintaining this after the original repo went away — the `receive_json` try/except and the `get_command` binary handling both fixed real crashes for us.