### PR TITLE
Fix broken env-var config fallback in download-local-files.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,11 +27,10 @@ lint/test/build commands. Key entry points:
   range; config from `NVRVideoDownloader.json` (or path in
   `$NVRVIDEODOWNLOADER_CFG`).
 - `python3 download-local-files.py` — solar/battery-camera pull loop; the
-  Docker `CMD`. Reads config from the JSON file at `$CONFIG_PATH`. (An
-  individual-env-var fallback exists in `load_config()` but is currently
-  broken — it does `Path(config_path)` with `config_path=None` when the
-  var is unset, and returns a plain dict where `main()` expects
-  attribute access — so treat `$CONFIG_PATH` as required.)
+  Docker `CMD`. Reads config from the JSON file at `$CONFIG_PATH`, or
+  falls back to individual env vars (`IP_ADDRESS`, `COOLDOWN`, ...) when
+  `$CONFIG_PATH` is unset. Both paths return the same attribute-accessible
+  namedtuple via `config_decoder`.
 - `python3 AlarmServer.py [port]` — standalone TCP server that logs
   `AlarmInfo` packets pushed by cameras configured to report to an
   external alarm center.

--- a/download-local-files.py
+++ b/download-local-files.py
@@ -22,11 +22,13 @@ def load_config():
         return namedtuple("X", config_dict.keys())(*config_dict.values())
 
     config_path = os.environ.get("CONFIG_PATH")
-    if Path(config_path).exists():
+    if config_path and Path(config_path).exists():
         with open(config_path, "r") as file:
             return json.loads(file.read(), object_hook=config_decoder)
 
-    return {
+    cooldown = os.environ.get("COOLDOWN")
+    dump_local_files = os.environ.get("DUMP_LOCAL_FILES")
+    return config_decoder({
         "host_ip": os.environ.get("IP_ADDRESS"),
         "user": os.environ.get("USER"),
         "password": os.environ.get("PASSWORD"),
@@ -36,11 +38,11 @@ def load_config():
         "start": os.environ.get("START"),
         "end": os.environ.get("END"),
         "blacklist_path": os.environ.get("BLACKLIST_PATH"),
-        "cooldown": int(os.environ.get("COOLDOWN")),
+        "cooldown": int(cooldown) if cooldown else 0,
         "dump_local_files": (
-            os.environ.get("DUMP_LOCAL_FILES").lower() in ["true", "1", "y", "yes"]
+            (dump_local_files or "").lower() in ["true", "1", "y", "yes"]
         ),
-    }
+    })
 
 
 def main():
@@ -51,7 +53,7 @@ def main():
     cooldown = config.cooldown
 
     blacklist = None
-    if Path(config.blacklist_path).exists():
+    if config.blacklist_path and Path(config.blacklist_path).exists():
         with open(config.blacklist_path, "r") as file:
             blacklist = [line.rstrip() for line in file]
 

--- a/download-local-files.py
+++ b/download-local-files.py
@@ -96,7 +96,12 @@ def main():
                     target_filetype=config.target_filetype_video,
                 )
 
-            if config.dump_local_files:
+            if config.dump_local_files and not config.blacklist_path:
+                logger.warning(
+                    "dump_local_files is enabled but blacklist_path is not set; "
+                    "skipping dump to avoid writing to 'None.dmp'."
+                )
+            elif config.dump_local_files:
                 logger.debug(f"Dumping local files...")
                 solarCam.dump_local_files(
                     videos,


### PR DESCRIPTION
## Summary

The individual-environment-variable configuration path in `download-local-files.py`'s `load_config()` was unusable. This was flagged during the CLAUDE.md review (OpenIPC/python-dvr#9); this PR fixes the underlying code.

## The bug

When `CONFIG_PATH` is unset and the caller relies on individual env vars, `load_config()` failed in three ways:

1. `Path(config_path).exists()` raised `TypeError` because `config_path` was `None` (`Path(None)`).
2. Even past that, the fallback returned a **plain dict**, but `main()` accesses the config via attributes (`config.start`, `config.cooldown`, ...), so it would raise `AttributeError`.
3. `int(os.environ.get("COOLDOWN"))` and `os.environ.get("DUMP_LOCAL_FILES").lower()` raised `TypeError` when those vars were unset.

## The fix

- Guard the `CONFIG_PATH` lookup so it's treated as optional (`config_path and Path(config_path).exists()`).
- Wrap the fallback dict in the same `config_decoder` namedtuple the JSON path already uses, so both branches return an attribute-accessible object.
- Tolerate missing `COOLDOWN` (default `0`) and `DUMP_LOCAL_FILES` (default off).
- Guard the optional `blacklist_path` in `main()` so an unset `BLACKLIST_PATH` doesn't re-introduce a `Path(None)` crash downstream.
- Update `CLAUDE.md` to describe the now-working fallback.

## Testing

Smoke-tested all three config paths — empty env (previously crashed), env-vars set, and JSON file via `CONFIG_PATH` — all return an attribute-accessible config with correct values.